### PR TITLE
make sure to return the return code from jgo

### DIFF
--- a/mobie/__init__.py
+++ b/mobie/__init__.py
@@ -33,4 +33,4 @@ def main():
 
     # subparsers don't specify any options, everything is passed to MoBiE
     args, unknown = p.parse_known_args()
-    args.func(mobie_options=unknown)
+    return args.func(mobie_options=unknown)


### PR DESCRIPTION
this requires https://github.com/scijava/jgo/pull/94

I propose to merge this already in any case - that way, once jgo is fixed, it will work by using updated jgo dependency.